### PR TITLE
Removed ereski and olamiko from DevOps on-call rotation.

### DIFF
--- a/helper-scripts/options/devOps.json
+++ b/helper-scripts/options/devOps.json
@@ -29,11 +29,9 @@
         "ab77": "ab77",
         "cmfcruz": "cmfcruz",
         "dfunckt": "dfunckt",
-        "ereski": "ereski",
         "jakogut": "jakogut",
         "joshbwlng": "josh.bowling",
         "klutchell": "klutchell",
-        "olamiko": "olamiko",
         "page-": "page"
     }
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>