### PR TITLE
Update balenaio optimization timeout

### DIFF
--- a/helper-scripts/options/balenaio.json
+++ b/helper-scripts/options/balenaio.json
@@ -8,7 +8,7 @@
   "shiftMaxDuration": 8,
   "useTwos": true,
   "useThrees" : false,
-  "optimizationTimeout": 1,
+  "optimizationTimeout": 5.5,
   "logSheet": "1HlYuuiVTXQwxei99a7KKBBzGHG3ggx38W99yjZY40TY",
   "calendarID":"resin.io_2klk2f26ivo04qq5ktlkva1neg@group.calendar.google.com",
   "specialAgentConditions": {


### PR DESCRIPTION
Change default value for `optimizationTimeout` from 1 hour to 5.5 hours. This change is needed for the scheduler to run via automated github action. Runners use only 2 CPUs and 1 hour is not sufficient to reach a decent proposal for a schedule.

Change-type: patch