### PR TITLE
Temporary reduce onboarding hours from 8 to 4.

### DIFF
--- a/algo-core/src/onboarding.py
+++ b/algo-core/src/onboarding.py
@@ -17,8 +17,8 @@ from ortools.sat.python import cp_model
 import pandas as pd
 
 # Onboarding (given in terms of number of 30-min slots):
-onboarding_shift_length = 8
-onboarding_weekly_slots = 16
+onboarding_shift_length = 4
+onboarding_weekly_slots = 8
 
 # In the model below, the following abbreviations are used:
 # d: day


### PR DESCRIPTION
We are onboarding non-engineers at the moment. Reduce onboarding hours from 8 to 4.

Change-type: patch