### PR TITLE
Sync VictorOps schedule start/end TZ to timezone.

### DIFF
--- a/helper-scripts/set-victorops-schedule.ts
+++ b/helper-scripts/set-victorops-schedule.ts
@@ -16,6 +16,7 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
 
+import * as moment from 'moment-timezone';
 import * as VictorOpsApiClient from 'victorops-api-client';
 import { readAndParseJSONSchedule } from '../lib/validate-json';
 
@@ -48,8 +49,8 @@ async function createScheduleOverrides(date, scheduleName) {
 					const { override } = await v.scheduledOverrides.createOverride({
 						username: 'balena',
 						timezone: TIMEZONE,
-						start: start.toISOString(),
-						end: end.toISOString(),
+						start: moment(start).tz(TIMEZONE).format(),
+						end: moment(end).tz(TIMEZONE).format(),
 					});
 					for (const assignment of override.assignments) {
 						await v.scheduledOverrides.updateAssignment(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/moment-timezone": "^0.5.30",
         "bluebird": "^3.7.2",
         "dotenv": "^16.0.3",
         "googleapis": "^109.0.1",
@@ -16,6 +17,7 @@
         "lodash": "^4.17.21",
         "log": "^6.3.1",
         "mkdirp": "^1.0.4",
+        "moment-timezone": "^0.5.43",
         "mz": "^2.7.0",
         "readline-sync": "^1.4.10",
         "ts-node": "^10.9.1",
@@ -388,6 +390,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/moment-timezone": {
+      "version": "0.5.30",
+      "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
+      "integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
+      "deprecated": "This is a stub types definition. moment-timezone provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "moment-timezone": "*"
       }
     },
     "node_modules/@types/mz": {
@@ -2310,6 +2321,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Balena",
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/moment-timezone": "^0.5.30",
     "bluebird": "^3.7.2",
     "dotenv": "^16.0.3",
     "googleapis": "^109.0.1",
@@ -30,6 +31,7 @@
     "lodash": "^4.17.21",
     "log": "^6.3.1",
     "mkdirp": "^1.0.4",
+    "moment-timezone": "^0.5.43",
     "mz": "^2.7.0",
     "readline-sync": "^1.4.10",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
VictorOps API started giving error 400 due to a difference between the selected timezone and the tz of the start/end override timestamps. This patch changes the timestamps to the correct timezone.

Change-type: patch