### PR TITLE
Standardize Zulip emails

### DIFF
--- a/helper-scripts/beautify-schedule.ts
+++ b/helper-scripts/beautify-schedule.ts
@@ -58,7 +58,7 @@ async function getZulipUsers() {
 	const usersByEmail: { [x: string]: string } = {};
 	for (const user of results.members) {
 		if (!user.is_bot && user.is_active) {
-			usersByEmail[user.email] = user.full_name;
+			usersByEmail[user.email.toLowerCase()] = user.full_name;
 		}
 	}
 	return usersByEmail;


### PR DESCRIPTION
Standardize (lowercase) Zulip emails, which are user-configurable.

We could also lowercase email coming from the Team Model

https://github.com/people-os/support-shift-scheduler/blob/f86c232be526c00a3cd4f7f1e4b5c2746015c2f0/helper-scripts/beautify-schedule.ts#L233

but maybe it's fair to assume that these are already standardized?