### PR TITLE
Load DevOps agent emails from Google Sheets

### DIFF
--- a/helper-scripts/set-devops-weekend-schedule.ts
+++ b/helper-scripts/set-devops-weekend-schedule.ts
@@ -16,7 +16,6 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
 
-import { promises as fs } from 'fs';
 import * as VictorOpsApiClient from 'victorops-api-client';
 import * as devOps from './options/devOps.json';
 import * as _ from 'lodash';
@@ -50,13 +49,94 @@ const calendar = google.calendar({ version: 'v3' });
 const DRY_RUN = process.env.DRY_RUN === 'true';
 const DAY_SKIP_MAX = 90;
 const DAYS_FORWARD_MAX = 123;
-async function loadHandleToEmail(inputDate: string) {
-	const inputFile = `logs/${inputDate}_${scheduleName}/support-shift-scheduler-input.json`;
-	const schedulerInput = JSON.parse(await fs.readFile(inputFile, 'utf8'));
-	return _(schedulerInput.agents)
-		.keyBy((a) => a.handle.replace(/^@/, ''))
-		.mapValues((a) => a.email)
-		.value();
+
+function requireEnv(name: string) {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`Environment variable ${name} is not set.`);
+	}
+	return value;
+}
+
+function parseColumn(name: string, fallback: string) {
+	// Empty values are rejected by validation rather than falling back.
+	const column = (process.env[name] ?? fallback).trim().toUpperCase();
+	if (!/^[A-Z]+$/.test(column)) {
+		throw new Error(
+			`Environment variable ${name} must be a column letter (e.g. A, B, AA), got '${column}'.`,
+		);
+	}
+	return column;
+}
+
+async function loadHandleToEmail() {
+	const spreadsheetId = requireEnv('DEVOPS_AGENT_DEFINITIONS_SPREADSHEET_ID');
+	const sheetName = requireEnv('DEVOPS_AGENT_DEFINITIONS_SHEET_NAME');
+	const handleColumn = parseColumn(
+		'DEVOPS_AGENT_DEFINITIONS_HANDLE_COLUMN',
+		'A',
+	);
+	const emailColumn = parseColumn('DEVOPS_AGENT_DEFINITIONS_EMAIL_COLUMN', 'B');
+	if (handleColumn === emailColumn) {
+		throw new Error(
+			'DEVOPS_AGENT_DEFINITIONS_HANDLE_COLUMN and DEVOPS_AGENT_DEFINITIONS_EMAIL_COLUMN must be different columns.',
+		);
+	}
+
+	const startRowValue = process.env.DEVOPS_AGENT_DEFINITIONS_START_ROW ?? '2';
+	const startRow = Number.parseInt(startRowValue, 10);
+	if (!Number.isInteger(startRow) || startRow < 1) {
+		throw new Error(
+			`Environment variable DEVOPS_AGENT_DEFINITIONS_START_ROW must be a positive integer, got '${startRowValue}'.`,
+		);
+	}
+
+	// With sheetName="Agents", this is "'Agents'".
+	const sheetPrefix = `'${sheetName.replace(/'/g, "''")}'`;
+	// With default values, this is "'Agents'!A2:A".
+	const handleRange = `${sheetPrefix}!${handleColumn}${startRow}:${handleColumn}`;
+	// With default values, this is "'Agents'!B2:B".
+	const emailRange = `${sheetPrefix}!${emailColumn}${startRow}:${emailColumn}`;
+
+	const auth = await getJWTAuthClient();
+	const sheets = google.sheets({ version: 'v4', auth });
+	const result = await sheets.spreadsheets.values.batchGet({
+		spreadsheetId,
+		ranges: [handleRange, emailRange],
+		valueRenderOption: 'FORMATTED_VALUE',
+	});
+
+	const [handleValueRange, emailValueRange] = result.data.valueRanges ?? [];
+	const handles = handleValueRange?.values ?? [];
+	const emails = emailValueRange?.values ?? [];
+
+	const handleToEmail: Record<string, string> = {};
+	const rowCount = Math.max(handles.length, emails.length);
+	for (let i = 0; i < rowCount; i++) {
+		// Read the first cell in the handle row, trim whitespace, and allow either "user" or "@user".
+		const handle = String(handles[i]?.[0] ?? '')
+			.trim()
+			.replace(/^@/, '');
+		// Read the first cell in the email row and normalize blank/missing cells to an empty string.
+		const email = String(emails[i]?.[0] ?? '').trim();
+		if (!handle && !email) {
+			continue;
+		}
+		if (!handle || !email) {
+			throw new Error(
+				`Missing handle or email in ${sheetName} row ${startRow + i}.`,
+			);
+		}
+		if (handleToEmail[handle]) {
+			throw new Error(`Duplicate GitHub handle '${handle}' in ${sheetName}.`);
+		}
+		handleToEmail[handle] = email;
+	}
+
+	if (_.isEmpty(handleToEmail)) {
+		throw new Error(`No agent definitions found in ${sheetName}.`);
+	}
+	return handleToEmail;
 }
 
 function getEmail(handleToEmail, ghName: string) {
@@ -263,19 +343,25 @@ function parseDate(input: string) {
 
 async function main() {
 	const args = process.argv.slice(2);
-	if (args.length < 2 || args.length > 3) {
+	if (args.length !== 2) {
 		console.log(
-			`Usage: node ${__filename} <start yyyy-mm-dd> <end yyyy-mm-dd> [input yyyy-mm-dd]`,
+			`Usage: node ${__filename} <start yyyy-mm-dd> <end yyyy-mm-dd>`,
 		);
 		console.log(
-			`The optional input date selects logs/<input>_${scheduleName}/support-shift-scheduler-input.json for agent emails. It defaults to the start date.`,
+			[
+				'Agent emails are loaded from Google Sheets using these environment variables:',
+				'DEVOPS_AGENT_DEFINITIONS_SPREADSHEET_ID',
+				'DEVOPS_AGENT_DEFINITIONS_SHEET_NAME',
+				'DEVOPS_AGENT_DEFINITIONS_HANDLE_COLUMN (defaults to A)',
+				'DEVOPS_AGENT_DEFINITIONS_EMAIL_COLUMN (defaults to B)',
+				'DEVOPS_AGENT_DEFINITIONS_START_ROW (defaults to 2)',
+			].join('\n'),
 		);
 		process.exit(1);
 	}
 	const startDate = parseDate(args[0]);
 	const endDate = parseDate(args[1]);
-	const inputDate = args[2] ?? args[0];
-	const handleToEmail = await loadHandleToEmail(inputDate);
+	const handleToEmail = await loadHandleToEmail();
 	const NOW = parseDate(Date());
 
 	if (DRY_RUN) {


### PR DESCRIPTION
Replace the `logs/*.json` handle-to-email lookup with a Google Sheets batchGet configured via `DEVOPS_AGENT_DEFINITIONS_*` env vars, and remove the now-unused optional input-date argument.

Change-type: patch